### PR TITLE
fix: Hilos no existentes de la clase Punto

### DIFF
--- a/Punto.cpp
+++ b/Punto.cpp
@@ -1,31 +1,21 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 /* 
  * File:   Punto.cpp
  * Author: Aybar
  * 
  * Created on September 14, 2017, 1:14 PM
  */
-
 #include "Punto.h"
 #include <fstream>
 #include <stdexcept>
 #include <string>
-#include <thread>
 using std::fstream;
 using std::string;
-using std::thread;
 Punto::Punto() {
     abscisa = 0;
     ordenada = 0;
     persist = std::vector<Punto>();
     try {
-        thread t(&Punto::leer, this);
-        t.join();
+		leer();
     } catch (string) {
 
     }
@@ -49,16 +39,14 @@ Punto Punto::buscar(const unsigned x) {
 
 bool Punto::alta(const int x, const int y) {
     persist.push_back(Punto(x, y));
-    thread t(&Punto::grabar, this);
-    t.join();
+	grabar();
     return true;
 
 }
 
 bool Punto::baja(const unsigned pos) {
     persist.erase(persist.begin() + pos);
-    thread t(&Punto::grabar, this);
-    t.join();
+	grabar();
     return true;
 
 }

--- a/Punto.h
+++ b/Punto.h
@@ -1,9 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 /* 
  * File:   Punto.h
  * Author: Aybar

--- a/main.cpp
+++ b/main.cpp
@@ -1,22 +1,15 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 /* 
  * File:   main.cpp
  * Author: aybar
  *
  * Created on September 14, 2017, 4:59 PM
  */
-
 #include <iostream>
 #include <map>  // Para coleccionar menu.
 #include <fstream> // Para archivo punto.txt.
 #include <string>
-#include <cctype>
-#include <limits> // toupper();
+#include <cctype> // toupper();
+#include <limits> // Valida entrada por teclado.
 #include "Punto.h"
 //-------------------------
 using std::cout;


### PR DESCRIPTION
La clase thread no existe dentro del espacio de nombres std.