### PR TITLE
Elimina la inclusion de la clase vector

### DIFF
--- a/IOInterface.h
+++ b/IOInterface.h
@@ -14,7 +14,6 @@
 #ifndef IOINTERFACE_H
 #define IOINTERFACE_H
 #include <string>
-#include <vector>
 
 class IOInterface {
 public:


### PR DESCRIPTION
Excluye la clase vector de las directivas include.

Es totalmente **redundante**, la invocación de la clase vector en este punto.